### PR TITLE
Fix family creation authorization error

### DIFF
--- a/app/controllers/families_controller.rb
+++ b/app/controllers/families_controller.rb
@@ -22,6 +22,7 @@ class FamiliesController < ApplicationController
 
     if @family.save
       current_user.update(family: @family)
+      current_user.reload  # Reload to ensure family association is fresh
       redirect_to @family, notice: 'Family was successfully created.'
     else
       render :new, status: :unprocessable_entity


### PR DESCRIPTION
## Summary
• Fixed authorization error preventing users from creating families
• Users were getting "You can only access your own family" error after successful family creation
• Added current_user.reload to ensure fresh family association data

## Test plan
- [ ] Create a new family as a user without an existing family
- [ ] Verify successful redirect to family show page without authorization error
- [ ] Confirm user can access their newly created family