### PR TITLE
Fix NoMethodError in milestones controller

### DIFF
--- a/app/controllers/milestones_controller.rb
+++ b/app/controllers/milestones_controller.rb
@@ -20,7 +20,7 @@ class MilestonesController < ApplicationController
   end
 
   def new
-    @milestone = (@milestoneable&.milestones || Milestone).build
+    @milestone = @milestoneable&.milestones&.build || Milestone.new
     @milestone_types = Milestone::MILESTONE_TYPES
   end
 


### PR DESCRIPTION
## Summary
- Fix NoMethodError when calling undefined `build` method on Milestone class
- Replace `Milestone.build` with proper association build method or `Milestone.new`
- Resolves runtime error preventing milestone creation

## Test plan
- [ ] Verify milestone creation form loads without error
- [ ] Test milestone creation with and without milestoneable objects
- [ ] Confirm existing milestone functionality remains intact